### PR TITLE
remove support for TLS 1.1 from dashboard

### DIFF
--- a/templates/dashboard.nginx.conf
+++ b/templates/dashboard.nginx.conf
@@ -10,7 +10,7 @@ server {
     server_name _;
     ssl_certificate {{ dashboard_tls_certificate_filepath }};
     ssl_certificate_key {{ dashboard_tls_key_filepath }};
-    ssl_protocols TLSv1.2;
+    ssl_protocols TLSv1.2 TLSv1.3;
     return 403;
 }
 
@@ -32,7 +32,7 @@ server {
     listen 443 ssl;
     ssl_certificate {{ dashboard_tls_certificate_filepath }};
     ssl_certificate_key {{ dashboard_tls_key_filepath }};
-    ssl_protocols TLSv1.2;
+    ssl_protocols TLSv1.2 TLSv1.3;
 
     # Secure Nginx from Clickjacking with X-FRAME-OPTIONS
     add_header X-Frame-Options "SAMEORIGIN";

--- a/templates/dashboard.nginx.conf
+++ b/templates/dashboard.nginx.conf
@@ -10,7 +10,7 @@ server {
     server_name _;
     ssl_certificate {{ dashboard_tls_certificate_filepath }};
     ssl_certificate_key {{ dashboard_tls_key_filepath }};
-    ssl_protocols TLSv1.1 TLSv1.2;
+    ssl_protocols TLSv1.2;
     return 403;
 }
 
@@ -32,7 +32,7 @@ server {
     listen 443 ssl;
     ssl_certificate {{ dashboard_tls_certificate_filepath }};
     ssl_certificate_key {{ dashboard_tls_key_filepath }};
-    ssl_protocols TLSv1.1 TLSv1.2;
+    ssl_protocols TLSv1.2;
 
     # Secure Nginx from Clickjacking with X-FRAME-OPTIONS
     add_header X-Frame-Options "SAMEORIGIN";


### PR DESCRIPTION
partially address https://github.com/GSA/datagov-deploy/issues/1706

similar to the wordpess nginix issue https://github.com/GSA/datagov-deploy/issues/1629