### PR TITLE
Fix pcntl intermittent error

### DIFF
--- a/molecule/default/tests/test_default.py
+++ b/molecule/default/tests/test_default.py
@@ -77,6 +77,12 @@ def test_supervisor_conf(host):
     assert supervisor.contains('user=%s' % dashboard_user)
 
 
+def test_pcntl_available(host):
+    cmd = host.run('php -m | grep pcntl')
+
+    assert cmd.stdout == 'pcntl\n'
+
+
 def test_cron(host):
     cron = host.file('/etc/cron.d/dashboard')
 

--- a/tasks/init.yml
+++ b/tasks/init.yml
@@ -1,15 +1,8 @@
 ---
 # Dashboard prerequisites
-- name: Enable the PHP pcntl extension
-  copy:
-    content: |-
-      extension=pcntl.so
-    dest: /etc/php/{{ dashboard_php_major_minor_version }}/fpm/conf.d/20-pcntl.ini
-    owner: root
-    group: root
-    mode: 0644
+- name: Remove invalid PHP .ini file
+  file: path=/etc/php/{{ dashboard_php_major_minor_version }}/fpm/conf.d/20-pcntl.ini state=absent
 
-# Dashboard prerequisites
 - name: Copying Dashboard configuration for Nginx
   template:
     src: "dashboard.nginx.conf"


### PR DESCRIPTION
pcntl is compiled directly into the PHP CLI binary, and explicitly left out of the FPM binary. 

Preston and I think that the reason for the intermittent error noted in https://github.com/GSA/datagov-deploy/issues/1801 is that when FPM starts up a new worker, it parses the .ini file that attempts to load the pcntl extension, even though its not available as a separate .so, and is never actually needed for requests that FPM handles. We're going to deploy this change, then see if we can still reproduce the error (which is already pretty rare).