### PR TITLE
set server_tokens off on role level, not individual site level

### DIFF
--- a/templates/dashboard.nginx.conf
+++ b/templates/dashboard.nginx.conf
@@ -43,7 +43,6 @@ server {
     add_header X-Frame-Options "SAMEORIGIN";
 
     # Remove default nginx headers
-    server_tokens off;
     more_clear_headers "Server";
     more_clear_headers "Cache-Control";
     more_clear_headers "Cache-Control";


### PR DESCRIPTION
For https://github.com/GSA/datagov-deploy/issues/1445

Go with https://github.com/GSA/datagov-deploy/pull/2609