### PR TITLE
[dashboard] return 404 for unknown hosts

### DIFF
--- a/templates/dashboard.nginx.conf
+++ b/templates/dashboard.nginx.conf
@@ -11,7 +11,7 @@ server {
     ssl_certificate {{ dashboard_tls_certificate_filepath }};
     ssl_certificate_key {{ dashboard_tls_key_filepath }};
     ssl_protocols TLSv1.2 TLSv1.3;
-    return 403;
+    return 404;
 }
 
 server {


### PR DESCRIPTION
https://github.com/GSA/datagov-deploy/pull/2636

404 is probably the best response for a host that is not supported.

403 implies that the [client may retry the URL with different credentials][1],
but that is not the case.

[1]: https://httpstatuses.com/403