### PR TITLE
add HSTS only for internal traffic

### DIFF
--- a/templates/dashboard.nginx.conf
+++ b/templates/dashboard.nginx.conf
@@ -102,11 +102,20 @@ server {
 
         add_header "Referrer-Policy" "origin";
 
-        add_header Strict-Transport-Security "max-age=31536000; includeSubdomains; ";
-
         #add_header "Content-Security-Policy" "default-src 'self' 'unsafe-inline' *.google-analytics.com *.googleapis.com cdn.datatables.net *.gov s.w.org; img-src *; font-src *";
 
         add_header X-Frame-Options "SAMEORIGIN";
+
+        # Avoid duplicate HSTS. Netscaler adds it for external traffic
+        if ( $host = $hostname ) {
+          set $internal_traffic 1;
+        }
+        if ( $host = {{ ansible_default_ipv4.address }} ) {
+          set $internal_traffic 1;
+        }
+        if ( $internal_traffic = 1 ) {
+          add_header Strict-Transport-Security "max-age=31536000; includeSubdomains; ";
+        }
 
         #NOTE: You should have "cgi.fix_pathinfo = 0;" in php.ini
         include fastcgi_params;


### PR DESCRIPTION
For GSA/datagov-deploy#2598.

Avoid duplicate HSTS. Netscaler adds it for external traffic.
This ensure Netsparker sees HSTS when it scan internal host, sees valid HSTS when it scans external URL.
This also means no HSTS for sandbox environment.