### PR TITLE
set internal traffic variable

### DIFF
--- a/templates/dashboard.nginx.conf
+++ b/templates/dashboard.nginx.conf
@@ -107,6 +107,7 @@ server {
         add_header X-Frame-Options "SAMEORIGIN";
 
         # Avoid duplicate HSTS. Netscaler adds it for external traffic
+        set $internal_traffic 0;
         if ( $host = $hostname ) {
           set $internal_traffic 1;
         }


### PR DESCRIPTION
get rid of repeated entry in nginx error log:
```
using uninitialized "Internal_traffic" variable ... 
```