### PR TITLE
reconfig for nginx 1.20+

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,9 +20,9 @@ composer. Add this role and its dependencies to your requirements.yml file.
   name: gsa.datagov-deploy-dashboard
 - src: geerlingguy.composer
 - src: geerlingguy.git
-- src: geerlingguy.nginx
 - src: geerlingguy.php
 - src: geerlingguy.php-versions
+- src: nginxinc.nginx
 ```
 
 Install with ansible-galaxy.
@@ -36,10 +36,10 @@ Example playbook.
 - name: install dashboard
   roles:
     - role: geerlingguy.git
-    - role: geerlingguy.nginx
     - role: geerlingguy.php-versions
     - role: geerlingguy.php
     - role: geerlingguy.composer
+    - role: nginxinc.nginx
     - role: gsa.datagov-deploy-dashboard
 ```
 

--- a/molecule/default/prepare.yml
+++ b/molecule/default/prepare.yml
@@ -15,16 +15,14 @@
 
   roles:
     - role: geerlingguy.git
-    - role: geerlingguy.nginx
-      nginx_remove_default_vhost: true
-      nginx_ppa_use: true
-      nginx_ppa_version: stable
-      nginx_extra_conf_options: |-
-        include /etc/nginx/modules-enabled/*.conf;
     - role: geerlingguy.php-versions
     - role: geerlingguy.php
       php_webserver_daemon: nginx
     - role: geerlingguy.composer
+    - role: nginxinc.nginx
+      vars:
+        nginx_branch: stable
+        nginx_state: latest
 
   tasks:
     - name: Create ubuntu user

--- a/molecule/default/prepare.yml
+++ b/molecule/default/prepare.yml
@@ -36,6 +36,7 @@
           - git
           - ssl-cert
           - supervisor
+          - iproute2
 
     - name: Install TLS host certificate
       copy:

--- a/molecule/default/requirements.yml
+++ b/molecule/default/requirements.yml
@@ -1,6 +1,6 @@
 ---
 - src: geerlingguy.composer
 - src: geerlingguy.git
-- src: geerlingguy.nginx
 - src: geerlingguy.php
 - src: geerlingguy.php-versions
+- src: nginxinc.nginx

--- a/tasks/init.yml
+++ b/tasks/init.yml
@@ -6,7 +6,7 @@
 - name: Copying Dashboard configuration for Nginx
   template:
     src: "dashboard.nginx.conf"
-    dest: "/etc/nginx/sites-enabled/dashboard.nginx.conf"
+    dest: "/etc/nginx/conf.d/default.conf"
   notify:
     - reload nginx
 
@@ -15,7 +15,6 @@
   with_items:
     - mariadb-client
     - php{{ dashboard_php_major_minor_version }}-zip
-    - nginx-extras
 
 - name: Remove old rollback code
   file: path="{{ project_source_rollback_path }}" state=absent

--- a/templates/dashboard.nginx.conf
+++ b/templates/dashboard.nginx.conf
@@ -43,11 +43,13 @@ server {
     add_header X-Frame-Options "SAMEORIGIN";
 
     # Remove default nginx headers
-    more_clear_headers "Server";
-    more_clear_headers "Cache-Control";
-    more_clear_headers "Cache-Control";
-    more_clear_headers "Pragma";
-    more_clear_headers "Expires";
+    ## new version of nginx 1.19+ does not have a good way to support
+    ## more_clear_headers. Disable them for now
+    # more_clear_headers "Server";
+    # more_clear_headers "Cache-Control";
+    # more_clear_headers "Cache-Control";
+    # more_clear_headers "Pragma";
+    # more_clear_headers "Expires";
 
     # Logging real client IPs instead of proxy/netscaler IP
     set_real_ip_from  10.0.0.0/8;


### PR DESCRIPTION
re-config how nginx is installed so we can use latest stable version.
Part of GSA/datagov-deploy#3287