### PR TITLE
add client_max_body_size to nginx

### DIFF
--- a/templates/dashboard.nginx.conf
+++ b/templates/dashboard.nginx.conf
@@ -29,6 +29,8 @@ server {
     #
     proxy_max_temp_file_size 0;
 
+    client_max_body_size: {{ client_max_body_size | default('1m') }}
+
     rewrite ^/dashboard/(.*) /$1;
 
     ## This should be in your http block and if it is, it's not needed here.


### PR DESCRIPTION
Did not see `client_max_body_size` support in `nginx_config_main_template` config, only in `nginx_config_http_template` config. Dashboard deploy is using a conf template file, therefore adding `client_max_body_size` here.